### PR TITLE
Test/GitHub Actions に push の都度実行するテストを追加

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,14 @@
+on: [push]
+
+jobs:
+    Reservation2-test:
+        runs-on: ubuntu-latest
+        name: dotnet-test
+        steps:
+        - name: Checkout
+            uses: actions/checkout@v2
+        - name: dotnet-test
+            uses: ./Test/ # Uses an action in the root directory
+            id: dotnet-test
+            with:
+                sln-path: '/github/workspace/content'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,14 +1,14 @@
 on: [push]
 
 jobs:
-    Reservation2-test:
-        runs-on: ubuntu-latest
-        name: dotnet-test
-        steps:
-        - name: Checkout
-            uses: actions/checkout@v2
-        - name: dotnet-test
-            uses: ./Test/ # Uses an action in the root directory
-            id: dotnet-test
-            with:
-                sln-path: '/github/workspace/content'
+  Reservation2-test:
+    runs-on: ubuntu-latest
+    name: dotnet-test
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: dotnet-test
+        uses: ./Test/ # Uses an action in the root directory
+        id: dotnet-test
+        with:
+          sln-path: '/github/workspace/content'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,4 +11,4 @@ jobs:
         uses: ./Test/ # Uses an action in the root directory
         id: dotnet-test
         with:
-          sln-path: '/github/workspace/content'
+          sln-path: '/github/workspace/Reservation2.sln'

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
+![.github/workflows/main.yml](https://github.com/ModelingKai/Reservation2/workflows/.github/workflows/main.yml/badge.svg)
+
 # README

--- a/Test/action.yml
+++ b/Test/action.yml
@@ -1,0 +1,15 @@
+name: "dotnet test"
+description: "dotnet test action"
+
+inputs:
+    :sln-path
+        required: true
+        default: '/github/workspace/Reservation2.sln'
+    
+runs:
+    using: 'docker'
+    image: 'mcr.microsoft.com/dotnet/core/sdk:3.1'
+    args:
+        - dotnet
+        - test
+        - ${{sln-path}}

--- a/Test/action.yml
+++ b/Test/action.yml
@@ -12,4 +12,4 @@ runs:
     args:
         - dotnet
         - test
-        - ${{sln-path}}
+        - ${{inputs.sln-path}}

--- a/Test/action.yml
+++ b/Test/action.yml
@@ -2,7 +2,7 @@ name: "dotnet test"
 description: "dotnet test action"
 
 inputs:
-    :sln-path
+    sln-path:
         required: true
         default: '/github/workspace/Reservation2.sln'
     


### PR DESCRIPTION
- push の都度、dotnet test を実行するよう追加しました。
- README.md に、最新テスト結果のバッジが出るようにしました。
- 今は従業員Idがないことでテストは失敗します。