### PR TITLE
Azure App Service 用の GitHub Actions を追加

### DIFF
--- a/.github/workflows/azure_app_service.yml
+++ b/.github/workflows/azure_app_service.yml
@@ -1,0 +1,43 @@
+# Docs for the Azure Web Apps Deploy action: https://github.com/Azure/webapps-deploy
+# More GitHub Actions for Azure: https://github.com/Azure/actions
+
+name: .NET Core CI
+
+on: [push]
+#  push:
+#    branches:
+#      - master
+
+env:
+  AZURE_WEBAPP_NAME: my-app-name    # set this to your application's name
+  AZURE_WEBAPP_PACKAGE_PATH: '.'    # set this to the path to your web app project, defaults to the repository root
+  DOTNET_VERSION: '3.1.301'         # set this to the dot net version to use
+
+jobs:
+  build-and-deploy:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@master
+
+    - name: Set up .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: ${{ env.DOTNET_VERSION }}
+
+    - name: Build with dotnet
+      run: dotnet build --configuration Release
+
+    - name: Test
+      run: dotnet test 
+
+    - name: dotnet publish
+      run: dotnet publish -c Release -o ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}/myapp
+
+    - name: Deploy to Azure Web App
+      uses: azure/webapps-deploy@v2
+      with:
+        app-name: 'modeling-kai'
+        slot-name: 'production'
+        publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
+        package: ${{env.AZURE_WEBAPP_PACKAGE_PATH}}/myapp


### PR DESCRIPTION
fix: #15 

Azure App Service にデプロイする GitHub Actions を追加しました。
デプロイ先の Azure App Service は、Shibata 個人のサブスクリプションのリソースで、無料プランのものです。

アプリケーションの URL はこちら。
https://modeling-kai.azurewebsites.net/